### PR TITLE
Hotfix: recipient  area optional value and more

### DIFF
--- a/js/ptc-admin-script.js
+++ b/js/ptc-admin-script.js
@@ -228,6 +228,10 @@ jQuery(document).ready(function ($) {
 function concatErrorMessages(errors) {
     let concatenatedErrors = '';
 
+    if (typeof errors === 'string') {
+        return errors;
+    }
+
     for (const [key, value] of Object.entries(errors)) {
         concatenatedErrors += `${value} \n`;
     }

--- a/pathao-bridge.php
+++ b/pathao-bridge.php
@@ -172,15 +172,15 @@ function pt_hms_create_new_order($order_data)
             'recipient_name' => sanitize_text_field($order_data['recipient_name']),
             'recipient_phone' => sanitize_text_field($order_data['recipient_phone']),
             'recipient_address' => sanitize_text_field($order_data['recipient_address']),
-            'recipient_city' => sanitize_text_field($order_data['recipient_city']),
-            'recipient_zone' => sanitize_text_field($order_data['recipient_zone']),
-            'recipient_area' => sanitize_text_field($order_data['recipient_area']),
+            'recipient_city' => (int)sanitize_text_field($order_data['recipient_city']),
+            'recipient_zone' => (int)sanitize_text_field($order_data['recipient_zone']),
+            'recipient_area' => (int)sanitize_text_field($order_data['recipient_area']),
             'delivery_type' => sanitize_text_field($order_data['delivery_type']),
             'item_type' => sanitize_text_field($order_data['item_type']),
             'special_instruction' => sanitize_text_field($order_data['special_instruction']),
             'item_quantity' => sanitize_text_field($order_data['item_quantity']),
             'item_weight' => sanitize_text_field($order_data['item_weight']),
-            'amount_to_collect' => sanitize_text_field($order_data['amount_to_collect']),
+            'amount_to_collect' => round(sanitize_text_field($order_data['amount_to_collect'])),
             'item_description' => sanitize_text_field($order_data['item_description'])
         ))
     );

--- a/plugin-api.php
+++ b/plugin-api.php
@@ -98,25 +98,23 @@ function ajax_pt_hms_create_new_order()
 function ajax_pt_wc_order_details()
 {
     
-    $orderId =  $_POST['order_id'] ?? null;
+    $orderId =  (int)$_POST['order_id'] ?? null;
 
     if (!$orderId) {
-        return wp_send_json_error('no_order_id', 'No order id found', 404);
+        wp_send_json_error('no_order_id', 'No order id found', 404);
     }
 
     $order = wc_get_order($orderId);
 
-
-
     if (!$order) {
-        return wp_send_json_error('no_order', 'No order found', 404);
+        wp_send_json_error('no_order', 'No order found', 404);
     }
 
     $orderData = $order->get_data();
     $orderItems = 0;
     $totalWeight = 0;
     // add items to order
-    $orderData['items'] = array_values(array_map(function($item) use (&$orderItems, &$totalWeight, $datePaid) {
+    $orderData['items'] = array_values(array_map(function($item) use (&$orderItems, &$totalWeight) {
 
         $quantity = $item->get_quantity();
         $totalWeight += (float)$item->get_product()->get_weight();


### PR DESCRIPTION
Closes #6

## Changelog
- Update plugin-api.php to remove some warning-level errors.
- Fix the JavaScript issue for creating orders if any validation occurs.
- Fix errors if the area is selected as optional.