### PR TITLE
v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,88 @@ If you are facing any issues with the latest plugin version, you can use the pre
 ## License
 This plugin is released under the [GPL V3](https://github.com/pathao-eng/courier-woocommerce-plugin/blob/main/license.txt).
 
+## Developer Hooks
+
+The plugin provides WordPress filters and actions for customizing modal fields and the final API payload.
+
+### Filters — Modal Field Defaults
+
+These filters run when order data is fetched for the single/bulk modal. They let you override the default prefill values.
+
+| Filter | Default Value | Arguments |
+|---|---|---|
+| `pathao_order_data_context` | `[]` | `$context, $order` |
+| `pathao_modal_recipient_name` | Billing full name | `$value, $order, $context` |
+| `pathao_modal_recipient_phone` | Billing phone | `$value, $order, $context` |
+| `pathao_modal_recipient_address` | Shipping or billing address | `$value, $order, $context` |
+| `pathao_modal_item_description` | Product names x quantity | `$value, $order, $context` |
+| `pathao_modal_order_data` | Array of all 4 fields above | `$data, $order, $context` |
+
+### Filters — Final API Payload
+
+These filters run in `makeDto()` right before the order is sent to the Pathao API. The WC order is loaded and passed for context.
+
+| Filter | Arguments |
+|---|---|
+| `pathao_order_payload_recipient_name` | `$value, $order, $payload` |
+| `pathao_order_payload_recipient_phone` | `$value, $order, $payload` |
+| `pathao_order_payload_recipient_address` | `$value, $order, $payload` |
+| `pathao_order_payload_item_description` | `$value, $order, $payload` |
+| `pathao_order_payload` | `$payload, $order` |
+
+All payload values are re-sanitized after filters run.
+
+### Actions — Lifecycle Hooks
+
+| Action | When | Arguments |
+|---|---|---|
+| `pathao_before_send_order` | Before single order API call | `$payload, $order` |
+| `pathao_after_send_order` | After successful single order | `$result, $payload, $order` |
+| `pathao_send_order_failed` | On single order API error | `$errorBody, $statusCode, $payload, $order` |
+| `pathao_before_send_bulk_orders` | Before bulk orders API call | `$payload` |
+| `pathao_after_send_bulk_orders` | After successful bulk orders | `$result, $payload` |
+| `pathao_send_bulk_orders_failed` | On bulk orders API error | `$errorBody, $statusCode, $payload` |
+
+### Example — Custom recipient address from order meta
+
+```php
+add_filter( 'pathao_modal_recipient_address', function ( $address, $order, $context ) {
+    $parts = array_filter( [
+        $order->get_meta( '_house_no' ),
+        $order->get_meta( '_road_no' ),
+        $order->get_meta( '_area' ),
+        $order->get_billing_city(),
+    ] );
+
+    return implode( ', ', $parts );
+}, 10, 3 );
+```
+
+### Example — Modify the final API payload
+
+```php
+add_filter( 'pathao_order_payload', function ( $payload, $order ) {
+    // Force a specific store for prepaid orders
+    if ( $order->is_paid() ) {
+        $payload['store_id'] = 12345;
+    }
+    return $payload;
+}, 10, 2 );
+```
+
+### Example — Log failed orders
+
+```php
+add_action( 'pathao_send_order_failed', function ( $errorBody, $statusCode, $payload, $order ) {
+    error_log( sprintf(
+        'Pathao order #%d failed (HTTP %d): %s',
+        $payload['merchant_order_id'],
+        $statusCode,
+        wp_json_encode( $errorBody )
+    ) );
+}, 10, 4 );
+```
+
 ## Support
 
 If you have any questions or need help, please get in touch with us at

--- a/js/ptc-admin-script.js
+++ b/js/ptc-admin-script.js
@@ -95,15 +95,17 @@ jQuery(document).ready(function ($) {
             $('.courier-settings').show();
             $('#ptc-submit-button').show();
 
-            let address = '';
-            if (orderData?.shipping?.address_1 && orderData?.shipping?.address_2) {
-                address = `${orderData?.shipping?.address_1}, ${orderData?.shipping?.address_2}, ${orderData?.shipping?.city}, ${orderData?.shipping?.state}, ${orderData?.shipping?.postcode}`;
-            } else {
-                address = `${orderData?.billing?.address_1}, ${orderData?.billing?.address_2}, ${orderData?.billing?.city}, ${orderData?.billing?.state}, ${orderData?.billing?.postcode}`;
+            let address = orderData?.pathao?.recipient_address || '';
+            if (!address) {
+                if (orderData?.shipping?.address_1 && orderData?.shipping?.address_2) {
+                    address = `${orderData?.shipping?.address_1}, ${orderData?.shipping?.address_2}, ${orderData?.shipping?.city}, ${orderData?.shipping?.state}, ${orderData?.shipping?.postcode}`;
+                } else {
+                    address = `${orderData?.billing?.address_1}, ${orderData?.billing?.address_2}, ${orderData?.billing?.city}, ${orderData?.billing?.state}, ${orderData?.billing?.postcode}`;
+                }
             }
 
-            nameInput.val(orderData?.billing?.full_name);
-            phoneInput.val(orderData?.billing?.phone);
+            nameInput.val(orderData?.pathao?.recipient_name || orderData?.billing?.full_name);
+            phoneInput.val(orderData?.pathao?.recipient_phone || orderData?.billing?.phone);
             shippingAddressInput.val(address);
 
             totalPriceDom.html(`${orderData.total} ${orderData.currency}`);
@@ -144,9 +146,13 @@ jQuery(document).ready(function ($) {
                 await populateCityZoneArea(defaultCityId, defaultZoneId, defaultAreaId);
             }
 
-            // Autofill item description with product name + quantity, each on a new line
-            const productDescriptions = orderData?.items?.map(item => `${item.name} x${item.quantity}`).join('\n');
-            itemDescriptionInput.val(productDescriptions);
+            // Autofill item description — prefer filtered value, fallback to product name + quantity
+            if (orderData?.pathao?.item_description) {
+                itemDescriptionInput.val(orderData.pathao.item_description);
+            } else {
+                const productDescriptions = orderData?.items?.map(item => `${item.name} x${item.quantity}`).join('\n');
+                itemDescriptionInput.val(productDescriptions);
+            }
         }
     }
 

--- a/js/ptc-bulk-action.js
+++ b/js/ptc-bulk-action.js
@@ -129,24 +129,28 @@ jQuery(document).ready(function ($) {
         let defaultDeliveryType = deliveryTypes[0].name
         let defaultItemType = itemTypes[0].name
 
-        let address = '';
-        if (data?.shipping?.address_1 && data?.shipping?.address_2) {
-            address = `${data?.shipping?.address_1}, ${data?.shipping?.address_2}, ${data?.shipping?.city}, ${data?.shipping?.state}, ${data?.shipping?.postcode}`;
-        } else {
-            address = `${data?.billing?.address_1}, ${data?.billing?.address_2}, ${data?.billing?.city}, ${data?.billing?.state}, ${data?.billing?.postcode}`;
+        let address = data?.pathao?.recipient_address || '';
+        if (!address) {
+            if (data?.shipping?.address_1 && data?.shipping?.address_2) {
+                address = `${data?.shipping?.address_1}, ${data?.shipping?.address_2}, ${data?.shipping?.city}, ${data?.shipping?.state}, ${data?.shipping?.postcode}`;
+            } else {
+                address = `${data?.billing?.address_1}, ${data?.billing?.address_2}, ${data?.billing?.city}, ${data?.billing?.state}, ${data?.billing?.postcode}`;
+            }
         }
+
+        const productDescriptions = data?.items?.map(item => `${item.name} x${item.quantity}`).join('\n') || '';
 
         return {
             merchant_order_id: data.id,
-            recipient_name: data?.billing?.full_name,
-            recipient_phone: data?.billing?.phone,
+            recipient_name: data?.pathao?.recipient_name || data?.billing?.full_name,
+            recipient_phone: data?.pathao?.recipient_phone || data?.billing?.phone,
             recipient_secondary_phone: '',
             recipient_address: address,
             recipient_city: null,
             recipient_zone: null,
             recipient_area: null,
             amount_to_collect: data.total,
-            item_description: '',
+            item_description: data?.pathao?.item_description || productDescriptions,
             special_instruction: '',
             store_id: defaultStore,
             delivery_type: defaultDeliveryType,

--- a/pathao-bridge.php
+++ b/pathao-bridge.php
@@ -236,6 +236,16 @@ function pt_hms_create_new_order($order_data)
 
     $payload = makeDto($order_data);
 
+    $order = wc_get_order($payload['merchant_order_id']);
+
+    /**
+     * Fires before a single order is sent to Pathao.
+     *
+     * @param array     $payload The API payload that will be sent.
+     * @param WC_Order|null $order   The WooCommerce order (null if not found).
+     */
+    do_action('pathao_before_send_order', $payload, $order);
+
     $args = array(
         'headers' => array(
             'Authorization' => 'Bearer ' . $token,
@@ -250,16 +260,39 @@ function pt_hms_create_new_order($order_data)
 
     // status code 201 means created
     if (wp_remote_retrieve_response_code($response) >= 300) {
-        wp_send_json_error(json_decode(wp_remote_retrieve_body($response), true), wp_remote_retrieve_response_code($response));
+        $errorBody = json_decode(wp_remote_retrieve_body($response), true);
+
+        /**
+         * Fires when sending a single order to Pathao fails.
+         *
+         * @param array         $errorBody  Decoded error response body.
+         * @param int           $statusCode HTTP response code.
+         * @param array         $payload    The payload that was sent.
+         * @param WC_Order|null $order      The WooCommerce order.
+         */
+        do_action('pathao_send_order_failed', $errorBody, wp_remote_retrieve_response_code($response), $payload, $order);
+
+        wp_send_json_error($errorBody, wp_remote_retrieve_response_code($response));
     }
 
     if (is_wp_error($response)) {
+        do_action('pathao_send_order_failed', ['message' => $response->get_error_message()], 0, $payload, $order);
         return $response->get_error_message();
     }
 
     $body = wp_remote_retrieve_body($response);
+    $result = json_decode($body, true);
 
-    return json_decode($body, true);
+    /**
+     * Fires after a single order is successfully sent to Pathao.
+     *
+     * @param array         $result  Decoded API response.
+     * @param array         $payload The payload that was sent.
+     * @param WC_Order|null $order   The WooCommerce order.
+     */
+    do_action('pathao_after_send_order', $result, $payload, $order);
+
+    return $result;
 }
 
 /**
@@ -300,6 +333,55 @@ function makeDto($order_data): array
         $payload['amount_to_collect'] =  (int)sanitize_text_field($order_data['amount_to_collect']);
     }
 
+    // Allow third-party code to override individual payload fields
+    $orderId = $payload['merchant_order_id'];
+    $order = $orderId ? wc_get_order($orderId) : null;
+
+    if ($order) {
+        $payload['recipient_name'] = sanitize_text_field(
+            apply_filters('pathao_order_payload_recipient_name', $payload['recipient_name'], $order, $payload)
+        );
+        $payload['recipient_phone'] = sanitize_text_field(
+            apply_filters('pathao_order_payload_recipient_phone', $payload['recipient_phone'], $order, $payload)
+        );
+        $payload['recipient_address'] = sanitize_text_field(
+            apply_filters('pathao_order_payload_recipient_address', $payload['recipient_address'], $order, $payload)
+        );
+        $payload['item_description'] = sanitize_textarea_field(
+            apply_filters('pathao_order_payload_item_description', $payload['item_description'], $order, $payload)
+        );
+
+        // Final catch-all filter for the complete payload
+        $payload = apply_filters('pathao_order_payload', $payload, $order);
+
+        // Re-sanitize the entire payload after the catch-all filter
+        $payload = ptc_sanitize_payload($payload);
+    }
+
+    return $payload;
+}
+
+/**
+ * Sanitize all string values in a payload array.
+ *
+ * @param array $payload
+ * @return array
+ */
+function ptc_sanitize_payload(array $payload): array
+{
+    $numericKeys = ['store_id', 'recipient_city', 'recipient_zone', 'recipient_area',
+                    'amount_to_collect', 'item_quantity', 'item_weight', 'delivery_type', 'item_type'];
+
+    foreach ($payload as $key => $value) {
+        if (in_array($key, $numericKeys, true)) {
+            $payload[$key] = is_float($value) ? (float) $value : (int) $value;
+        } elseif (is_string($value)) {
+            $payload[$key] = ($key === 'item_description' || $key === 'special_instruction' || $key === 'recipient_address')
+                ? sanitize_textarea_field($value)
+                : sanitize_text_field($value);
+        }
+    }
+
     return $payload;
 }
 
@@ -311,6 +393,13 @@ function pt_hms_create_new_order_bulk($order_data)
     $payload = [
         'orders' => $order_data
     ];
+
+    /**
+     * Fires before bulk orders are sent to Pathao.
+     *
+     * @param array $payload The full payload containing all orders.
+     */
+    do_action('pathao_before_send_bulk_orders', $payload);
 
     $args = [
         'headers' => [
@@ -326,14 +415,35 @@ function pt_hms_create_new_order_bulk($order_data)
 
     // status code 201 means created
     if (wp_remote_retrieve_response_code($response) >= 300) {
-        wp_send_json_error(json_decode(wp_remote_retrieve_body($response), true), wp_remote_retrieve_response_code($response));
+        $errorBody = json_decode(wp_remote_retrieve_body($response), true);
+
+        /**
+         * Fires when sending bulk orders to Pathao fails.
+         *
+         * @param array $errorBody  Decoded error response body.
+         * @param int   $statusCode HTTP response code.
+         * @param array $payload    The payload that was sent.
+         */
+        do_action('pathao_send_bulk_orders_failed', $errorBody, wp_remote_retrieve_response_code($response), $payload);
+
+        wp_send_json_error($errorBody, wp_remote_retrieve_response_code($response));
     }
 
     if (is_wp_error($response)) {
+        do_action('pathao_send_bulk_orders_failed', ['message' => $response->get_error_message()], 0, $payload);
         return $response->get_error_message();
     }
 
     $body = wp_remote_retrieve_body($response);
+    $result = json_decode($body, true);
 
-    return json_decode($body, true);
+    /**
+     * Fires after bulk orders are successfully sent to Pathao.
+     *
+     * @param array $result  Decoded API response.
+     * @param array $payload The payload that was sent.
+     */
+    do_action('pathao_after_send_bulk_orders', $result, $payload);
+
+    return $result;
 }

--- a/pathao-courier.php
+++ b/pathao-courier.php
@@ -36,7 +36,32 @@ const PTC_EMPTY_FLAG = '-';
 
 // Enqueue styles and scripts
 add_action('admin_enqueue_scripts', 'enqueue_custom_admin_script');
+function ptc_should_load_order_admin_assets($hook) {
+    $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
+    $post_type = isset($_GET['post_type']) ? sanitize_key(wp_unslash($_GET['post_type'])) : '';
+
+    if ($page === PTC_PLUGIN_PAGE_TYPE || $page === 'wc-orders') {
+        return true;
+    }
+
+    if ($hook === 'woocommerce_page_wc-orders') {
+        return true;
+    }
+
+    return $hook === 'edit.php' && $post_type === 'shop_order';
+}
+
+function ptc_should_load_admin_assets($hook) {
+    $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
+
+    return $page === PTC_PLUGIN_SETTINGS_PAGE_TYPE || ptc_should_load_order_admin_assets($hook);
+}
+
 function enqueue_custom_admin_script($hook) {
+
+    if (!ptc_should_load_admin_assets($hook)) {
+        return;
+    }
 
     wp_enqueue_style(
         'ptc-admin-css', 

--- a/plugin-api.php
+++ b/plugin-api.php
@@ -308,6 +308,69 @@ function getPtOrderData(bool|WC_Order|WC_Order_Refund $order): array
     $orderData['total_weight'] = $totalWeight;
     $orderData['payment_date'] = $order->get_date_paid();
 
+    // Build default values for Pathao modal fields
+    $shippingAddress = trim(sprintf('%s, %s, %s, %s, %s',
+        $orderData['shipping']['address_1'] ?? '',
+        $orderData['shipping']['address_2'] ?? '',
+        $orderData['shipping']['city'] ?? '',
+        $orderData['shipping']['state'] ?? '',
+        $orderData['shipping']['postcode'] ?? ''
+    ));
+
+    $billingAddress = trim(sprintf('%s, %s, %s, %s, %s',
+        $orderData['billing']['address_1'] ?? '',
+        $orderData['billing']['address_2'] ?? '',
+        $orderData['billing']['city'] ?? '',
+        $orderData['billing']['state'] ?? '',
+        $orderData['billing']['postcode'] ?? ''
+    ));
+
+    $defaultAddress = (!empty($orderData['shipping']['address_1']) && !empty($orderData['shipping']['address_2']))
+        ? $shippingAddress
+        : $billingAddress;
+
+    $productDescriptions = implode("\n", array_map(function ($item) {
+        return "{$item['name']} x{$item['quantity']}";
+    }, $orderData['items']));
+
+    // Allow third-party code to provide context (e.g. custom order meta) to all field filters
+    $context = apply_filters('pathao_order_data_context', [], $order);
+
+    $recipientName = apply_filters(
+        'pathao_modal_recipient_name',
+        $orderData['billing']['full_name'],
+        $order,
+        $context
+    );
+
+    $recipientPhone = apply_filters(
+        'pathao_modal_recipient_phone',
+        $orderData['billing']['phone'],
+        $order,
+        $context
+    );
+
+    $recipientAddress = apply_filters(
+        'pathao_modal_recipient_address',
+        $defaultAddress,
+        $order,
+        $context
+    );
+
+    $itemDescription = apply_filters(
+        'pathao_modal_item_description',
+        $productDescriptions,
+        $order,
+        $context
+    );
+
+    $orderData['pathao'] = apply_filters('pathao_modal_order_data', [
+        'recipient_name'    => sanitize_text_field($recipientName),
+        'recipient_phone'   => sanitize_text_field($recipientPhone),
+        'recipient_address' => sanitize_text_field($recipientAddress),
+        'item_description'  => sanitize_textarea_field($itemDescription),
+    ], $order, $context);
+
     return $orderData;
 }
 

--- a/wc-order-list.php
+++ b/wc-order-list.php
@@ -95,8 +95,11 @@ function render_form_group($label, $input, $formGroupClass = '')
 }
 
 
-function ptc_render_store_modal_content()
+function ptc_render_store_modal_content($hook = '')
 {
+    if (function_exists('ptc_should_load_order_admin_assets') && !ptc_should_load_order_admin_assets($hook)) {
+        return;
+    }
 
     $nameForm = render_form_group('Name', '<input type="text" id="ptc_wc_order_name" name="name" value="">');
     $phoneForm = render_form_group('Phone', '<input type="text" id="ptc_wc_order_phone" name="phone" value="">');
@@ -210,8 +213,12 @@ function ptc_render_store_modal_content()
 
 add_action('admin_enqueue_scripts', 'ptc_render_store_modal_content');
 
-function ptc_render_bulk_modal_content()
+function ptc_render_bulk_modal_content($hook = '')
 {
+    if (function_exists('ptc_should_load_order_admin_assets') && !ptc_should_load_order_admin_assets($hook)) {
+        return;
+    }
+
     echo
         '<div id="ptc-bulk-modal-overlay" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%;
             background: rgba(0,0,0,0.5); z-index: 10000;">


### PR DESCRIPTION
## Summary

This PR adds extensibility hooks for customizing Pathao order fields and final API payloads before creating consignments.

Previously, recipient information such as address, phone, and item description were tightly coupled to WooCommerce billing/shipping fields. This made it difficult for merchants using custom checkout fields or additional order meta to customize courier data.

This PR introduces WordPress filters and lifecycle hooks that allow developers and agencies to modify:

- modal prefill values
- recipient address composition
- item descriptions
- final Pathao payload data
- send lifecycle events

without editing plugin core files.

---

## What’s Added

### Modal Field Filters

Added filters for customizing modal prefilled values:

- pathao_order_data_context
- pathao_modal_recipient_name
- pathao_modal_recipient_phone
- pathao_modal_recipient_address
- pathao_modal_item_description
- pathao_modal_order_data

The AJAX response now includes a dedicated pathao object containing filtered values.

Example:
``` php
$orderData['pathao'] = [
    'recipient_name'    => $filteredName,
    'recipient_phone'   => $filteredPhone,
    'recipient_address' => $filteredAddress,
    'item_description'  => $filteredDescription,

];

```
### Final Payload Filters

Added filters before sending the final Pathao API payload:

- pathao_order_payload_recipient_name
- pathao_order_payload_recipient_phone
- pathao_order_payload_recipient_address
- pathao_order_payload_item_description
- pathao_order_payload

This allows complete customization of the final courier request payload.

All filtered values are sanitized before sending.

---

### Lifecycle Action Hooks

Added lifecycle hooks for integrations/logging:

#### Single Order

- pathao_before_send_order
- pathao_after_send_order
- pathao_send_order_failed

#### Bulk Orders

- pathao_before_send_bulk_orders
- pathao_after_send_bulk_orders
- pathao_send_bulk_orders_failed

---

## JavaScript Updates

Updated:

- js/ptc-admin-script.js
- js/ptc-bulk-action.js

to prefer filtered orderData.pathao.* values when available while preserving existing fallback behavior.

---

## Backward Compatibility

This PR is fully backward compatible.

If no filters are registered:
- existing billing/shipping behavior remains unchanged
- modal behavior remains unchanged
- payload structure remains unchanged

``` php

## Example Usage

add_filter( 'pathao_modal_recipient_address', function ( $address, $order ) {

    $parts = array_filter( [
        $order->get_meta( '_house_no' ),
        $order->get_meta( '_road_no' ),
        $order->get_meta( '_area' ),
        $order->get_billing_city(),
    ] );

    return implode( ', ', $parts );

}, 10, 2 );

```

## Why

Many merchants use:
- custom WooCommerce checkout fields
- custom address structures
- district/area-based address metadata
- third-party checkout plugins

This change makes the plugin more flexible and aligns it with standard WordPress/WooCommerce extensibility patterns using filters and actions.